### PR TITLE
Added a response parser and a way to use the response parser and the API

### DIFF
--- a/scala-akka/src/main/scala/org/openapitools/client/core/ResponseParsers.scala
+++ b/scala-akka/src/main/scala/org/openapitools/client/core/ResponseParsers.scala
@@ -1,0 +1,36 @@
+package org.openapitools.client.core
+
+import org.openapitools.client.model.{Currency, CurrencyEnums, CurrencyWithdrawalPriorities}
+
+import scala.collection.immutable.HashMap.HashTrieMap
+import scala.util.{Failure, Success, Try}
+
+object ResponseParsers {
+  def withCurrenciesParser[U](withFunction : List[Currency] => U): Try[ApiResponse[Any]] => U = {
+    case Success(res) => {
+      val contentMap = res.content.asInstanceOf[HashTrieMap[String, Any]]
+      val results = contentMap.get("result").get.asInstanceOf[List[HashTrieMap[String, Any]]]
+      val all = results.map(result => {
+        val priorities = Some(result.get("withdrawal_priorities").get.asInstanceOf[List[Map[String, Any]]]
+          .map(e => CurrencyWithdrawalPriorities(e.get("name").get.asInstanceOf[String],
+            e.get("value").get.asInstanceOf[Double])))
+        Currency(
+          result.get("min_confirmations").asInstanceOf[Option[BigInt]].map(_.toInt),
+          result.get("withdrawal_fee").asInstanceOf[Option[Double]],
+          None,
+          result.get("currency").get.asInstanceOf[String],
+          result.get("currency_long").get.asInstanceOf[String],
+          result.get("withdrawal_fee").get.asInstanceOf[Double],
+          result.get("fee_precision").asInstanceOf[Option[BigInt]].map(_.toInt),
+          priorities,
+          CurrencyEnums.CoinType.withName(result.get("coin_type").get.asInstanceOf[String])
+        )
+      }
+      )
+      withFunction(all)
+    }
+    case Failure(e) => {
+      withFunction(List[Currency]())
+    }
+  }
+}

--- a/scala-akka/src/test/scala/org/openapitools/client/ResponseParserTest.scala
+++ b/scala-akka/src/test/scala/org/openapitools/client/ResponseParserTest.scala
@@ -1,0 +1,32 @@
+import org.scalatest.AsyncFunSpec
+import akka.actor.ActorSystem
+import org.openapitools.client.api.MarketDataApi
+import org.openapitools.client.core.{ApiInvoker, ApiResponse, BasicCredentials, ResponseParsers}
+import org.openapitools.client.model.CurrencyEnums
+
+import scala.concurrent.Future
+import scala.util.Try
+
+class ResponseParserTest extends AsyncFunSpec {
+  val email = "bob@example.com"
+  val password = "password"
+
+  describe("The first list of response parsers.") {
+    it("A response parser example where a list of currencies are obtained.") {
+      val credentials = new BasicCredentials(email, password)
+      val bitcoin: String = CurrencyEnums.CoinType.BITCOIN.toString()
+      val request = MarketDataApi.apply().publicGetCurrenciesGet()(credentials)
+      val invoker = ApiInvoker()(ActorSystem())
+      val future : Future[ApiResponse[Any]] = invoker.execute(request)
+      val primaryFuture = future.map(response => {
+        println("Parsing Api response")
+        ResponseParsers.withCurrenciesParser(currencyList => {
+          println(currencyList.toString())
+        })(Try(response))
+        assert(2 == 2)
+      })
+      println(s"Done main thread")
+      primaryFuture
+    }
+  }
+}


### PR DESCRIPTION
At first I found the scala-akka API very difficult to use and wrap my head around so I have provided a test case that shows how the API can be used. I also provided a parser file that contains parsers which can turn the responses into objects contained in the models folder.